### PR TITLE
Classifier: remove `label_probabilities` hashmap, and just store highest running probability 

### DIFF
--- a/src/classifier.rs
+++ b/src/classifier.rs
@@ -30,10 +30,13 @@ impl NaiveBayesClassifier {
   // Get a guess of input text based on existing unigram counts
   pub fn guess(&self, text: &str) -> String {
     let stemmed_and_tokenized = get_tokenized_and_stemmed(text);
-    let mut label_probabilities = HashMap::new();
+
+    let mut result_label = String::new();
+    let mut result_probability = 0.0;
 
     for (classification, word_counts) in self.documents.iter() {
       //Get the probability that the passed-in text is each class
+      let mut normalized_prob = 0.0;
       let mut probability = 0.0f32;
       for stemmed_word in &stemmed_and_tokenized {
         if word_counts.contains_key(stemmed_word) {
@@ -43,24 +46,17 @@ impl NaiveBayesClassifier {
 
       // store the calculated probability for the classification
       if probability.abs() < 0.0001 {
-        label_probabilities.insert(classification, 0.0);
+        normalized_prob = 0.0;
       } else {
-        let normalized_prob = word_counts.len() as f32 * probability.abs() /
-                              self.total_document_count as f32;
-
-        label_probabilities.insert(classification, normalized_prob);
+        normalized_prob = word_counts.len() as f32 * probability.abs() /
+                          self.total_document_count as f32;
       }
-    }
-    
-    // determine the label of the highest probability
-    let mut result_label = String::new();
-    let mut result_probability = 0.0;
-    for (classification, prob) in label_probabilities.into_iter() {
-      if result_probability <= prob {
+      if result_probability <= normalized_prob {
+        result_probability = normalized_prob;
         result_label = classification.clone();
-        result_probability = prob;
       }
     }
+
     result_label
   }
 }

--- a/tests/classification_tests.rs
+++ b/tests/classification_tests.rs
@@ -1,7 +1,6 @@
 extern crate natural;
 
 use natural::classifier::NaiveBayesClassifier;
-use test::Bencher;
 
 #[test]
 fn test_basic_usage() {

--- a/tests/classification_tests.rs
+++ b/tests/classification_tests.rs
@@ -1,6 +1,7 @@
 extern crate natural;
 
 use natural::classifier::NaiveBayesClassifier;
+use test::Bencher;
 
 #[test]
 fn test_basic_usage() {


### PR DESCRIPTION
This isn't a major optimization, but you can simply just remove the HashMap `label_probabilities` from the classifier and just store the highest running probability. This way you don't need a HashMap or another loop. You simply just store the `result_label` and `result_probability` each time the probability is higher than the last highest probability stored in `result_probability`. Another solution I looked at is to use a vector of tuples `Vector<(String, f32)>` and just allocating the vector(construct using `with_capacity`) with a fixed size that is exactly the size of the amount of documents(`self.count`) to prevent reallocation, because you don't really need to access the label by the key and you aren't really using any methods of a HashMap that you'd be missing by using a Vector instead. But this is also unnecessary, because you're only passing back the highest label rather than all the labels and probabilities. This should reduce overhead of heap allocating a HashMap, storing unused values, and reduce overhead of having a second loop.

All tests are passing on my local.