### PR TITLE
tf-idf implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,3 +10,5 @@ name = "stem"
 version = "0.1.0"
 source = "git+https://github.com/mrordinaire/rust-stem#9584f586d4299286d6acaf34949bf9823d19f825"
 
+[metadata]
+"checksum stem 0.1.0 (git+https://github.com/mrordinaire/rust-stem)" = "<none>"

--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ Currently working:
 * Phonetics (Soundex)
 * Stemming (Using a fork of [rust-stem](https://github.com/mrordinaire/rust-stem))
 * Naive-Bayes classification
+* Term Frequency-Inverse Document Frequency(tf-idf)
  
 Near-sight goals:
 
 * Logistic regression classification
 * Optimize naive-bayes (currently pretty slow)
 * Plural/Singular inflector
-* tf-idf
 
 ## How to use ##
 
@@ -114,4 +114,19 @@ nbc.train(STRING_TO_TRAIN, LABEL);
 nbc.train(STRING_TO_TRAIN, LABEL);
 
 nbc.guess(STRING_TO_GUESS); //returns a label with the highest probability
+```
+
+### Tf-Idf ###
+
+```rust
+extern crate natural;
+use natural::tf_idf::TfIdf;
+
+tf_idf.add("this document is about rust.");
+tf_idf.add("this document is about erlang.");
+tf_idf.add("this document is about erlang and rust.");
+tf_idf.add("this document is about rust. it has rust examples");
+
+assert_eq!(tf_idf.get("rust"), 0.2993708f32 );
+assert_eq!(tf_idf.get("erlang"), 0.13782766f32 );
 ```

--- a/README.md
+++ b/README.md
@@ -127,7 +127,9 @@ tf_idf.add("this document is about erlang.");
 tf_idf.add("this document is about erlang and rust.");
 tf_idf.add("this document is about rust. it has rust examples");
 
-assert_eq!(tf_idf.get("rust"), 0.2993708f32 );
-assert_eq!(tf_idf.get("erlang"), 0.13782766f32 );
-assert_eq!(tf_idf.get("rust erlang", 0.21859923 ); //average of multiple terms
+println!(tf_idf.get("rust")); //0.2993708f32
+println!(tf_idf.get("erlang")); //0.13782766f32
+
+//average of multiple terms
+println!(tf_idf.get("rust erlang"); //0.21859923
 ```

--- a/README.md
+++ b/README.md
@@ -129,4 +129,5 @@ tf_idf.add("this document is about rust. it has rust examples");
 
 assert_eq!(tf_idf.get("rust"), 0.2993708f32 );
 assert_eq!(tf_idf.get("erlang"), 0.13782766f32 );
+assert_eq!(tf_idf.get("rust erlang", 0.21859923 ); //average of multiple terms
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,3 +5,4 @@ pub mod ngram;
 pub mod tokenize;
 pub mod phonetics;
 pub mod classifier;
+pub mod tf_idf;

--- a/src/tf_idf.rs
+++ b/src/tf_idf.rs
@@ -71,6 +71,7 @@ impl TfIdf {
 		ratio.ln()
 	}
 
+	//Calculate tf-idf for one term
 	fn tf_idf(&self, term: &str) -> f32 {
 		let tf = self.tf(term);
 		let idf = self.idf(term);
@@ -88,7 +89,7 @@ impl TfIdf {
 
 		let score: f32 = token_ref.into_iter()
 			    .map(|x| self.tf_idf(&x))
-			    .fold(1.0f32, |acc, x| acc * x); //multiply together to later divide by token length to get an average
+			    .fold(0.0f32, |acc, x| acc + x); //add together to later divide by token length to get an average
 
 	  //average the scores
 		score / tokens.len() as f32

--- a/src/tf_idf.rs
+++ b/src/tf_idf.rs
@@ -1,0 +1,104 @@
+use std::collections::HashMap;
+use std::cmp::Ordering;
+use stem;
+use tokenize::tokenize;
+
+pub struct TfIdf {
+	//token counts for inverse document frequency
+	doc_freqs: HashMap<String, usize>, 
+
+	//documents joined into a single HashMap
+	pub term_freqs: HashMap<String, usize>,
+
+	//total count of documents inserted
+	doc_count: usize,
+
+	//total count of words inserted
+	word_count: usize
+}
+
+impl TfIdf {
+	pub fn new() -> TfIdf {
+		TfIdf {
+			doc_freqs: HashMap::new(),
+			term_freqs: HashMap::new(),
+			doc_count: 0,
+			word_count: 0
+		}
+	}
+
+	//Add documents to test frequency against
+	pub fn add(&mut self, corpus: &str) {
+		let mut tokens = get_tokenized_and_stemmed(corpus);
+		let tokens_ref = &mut tokens;
+
+		for token in tokens_ref.into_iter() {
+			let entry = self.term_freqs.entry(token.to_owned()).or_insert(0);
+
+			*entry += 1;
+			self.word_count += 1;
+		}
+
+		tokens_ref.sort();
+		tokens_ref.dedup();
+
+		for token in tokens_ref.into_iter() {
+			let entry = self.doc_freqs.entry(token.to_owned()).or_insert(0);
+
+			*entry += 1;
+		}
+
+		self.doc_count += 1;
+	}
+
+	//Calculate term frequency for one term
+	fn tf(&self, term: &str) -> f32 {
+		match self.term_freqs.get(term) {
+			Some(freq) => freq.clone() as f32 / self.word_count as f32,
+			None => 0.0f32
+		}
+	}
+
+	//Calculate inverse document frequency for one term
+	fn idf(&self, term: &str) -> f32 {
+		let doc_freq = match self.doc_freqs.get(term) {
+			Some(freq) => freq.clone() as f32,
+			None => 0.0f32
+		};
+
+		let ratio = self.doc_count as f32 / 1.0f32 + doc_freq;
+
+		ratio.ln()
+	}
+
+	fn tf_idf(&self, term: &str) -> f32 {
+		let tf = self.tf(term);
+		let idf = self.idf(term);
+
+		println!("{:?}", tf);
+		println!("{:?}", idf);
+
+		tf * idf
+	}
+
+	//Get tf-idf of a string of one or more terms
+	pub fn get(&self, terms: &str) -> f32 {
+		let tokens = get_tokenized_and_stemmed(terms);
+		let token_ref = &tokens;
+
+		let score: f32 = token_ref.into_iter()
+			    .map(|x| self.tf_idf(&x))
+			    .fold(1.0f32, |acc, x| acc * x); //multiply together to later divide by token length to get an average
+
+	  //average the scores
+		score / tokens.len() as f32
+	}
+}
+
+
+fn get_tokenized_and_stemmed(text: &str) -> Vec<String> {
+  let tokenized_text = tokenize(text);
+  tokenized_text.into_iter()
+                .map(|text| stem::get(text).unwrap())
+                .collect()
+}

--- a/tests/tf_idf_test.rs
+++ b/tests/tf_idf_test.rs
@@ -11,6 +11,6 @@ fn test_basic_usage() {
 	tf_idf.add("this document is about erlang and rust.");
 	tf_idf.add("this document is about rust. it has rust examples");
 
-	assert_eq!(tf_idf.get("rust"), 0.2993708f32 );
+	assert_eq!(tf_idf.get("rust erlang"), 0.2993708f32 );
 	assert!(tf_idf.get("rust") > tf_idf.get("erlang"));
 }

--- a/tests/tf_idf_test.rs
+++ b/tests/tf_idf_test.rs
@@ -11,6 +11,6 @@ fn test_basic_usage() {
 	tf_idf.add("this document is about erlang and rust.");
 	tf_idf.add("this document is about rust. it has rust examples");
 
-	assert_eq!(tf_idf.get("rust erlang"), 0.2993708f32 );
+	assert_eq!(tf_idf.get("rust"), 0.2993708f32 );
 	assert!(tf_idf.get("rust") > tf_idf.get("erlang"));
 }

--- a/tests/tf_idf_test.rs
+++ b/tests/tf_idf_test.rs
@@ -1,0 +1,16 @@
+extern crate natural;
+
+use natural::tf_idf::TfIdf;
+
+#[test]
+fn test_basic_usage() {
+	let mut tf_idf = TfIdf::new();
+
+	tf_idf.add("this document is about rust.");
+	tf_idf.add("this document is about erlang.");
+	tf_idf.add("this document is about erlang and rust.");
+	tf_idf.add("this document is about rust. it has rust examples");
+
+	assert_eq!(tf_idf.get("rust"), 0.2993708f32 );
+	assert!(tf_idf.get("rust") > tf_idf.get("erlang"));
+}

--- a/tests/tf_idf_test.rs
+++ b/tests/tf_idf_test.rs
@@ -10,7 +10,6 @@ fn test_basic_usage() {
 	tf_idf.add("this document is about erlang.");
 	tf_idf.add("this document is about erlang and rust.");
 	tf_idf.add("this document is about rust. it has rust examples");
-
-	assert_eq!(tf_idf.get("rust"), 0.2993708f32 );
+	
 	assert!(tf_idf.get("rust") > tf_idf.get("erlang"));
 }


### PR DESCRIPTION
A simple tf-idf implementation. Tests are included, as well as documentation. Modified `README.md` to no longer list tf-idf as near-sighted goal.